### PR TITLE
Switch to using crop percentages

### DIFF
--- a/app/assets/javascripts/jcrop_data_objects.js
+++ b/app/assets/javascripts/jcrop_data_objects.js
@@ -1,8 +1,8 @@
 $(function(){
-  var $target_image = $('#permalink img:first');
-  var $crop_form = $('#crop_form form');
+  var $targetImage = $('#permalink img:first');
+  var $cropForm = $('#crop_form form');
 
-  $target_image.Jcrop({
+  $targetImage.Jcrop({
     onChange: showPreview,
     onSelect: updatePreviewForm,
     onRelease: resetPreview,
@@ -11,11 +11,11 @@ $(function(){
     aspectRatio: 1
   });
 
-  $target_image.closest('a').on('click', function(e) {
+  $targetImage.closest('a').on('click', function(e) {
       e.preventDefault();
   });
 
-  $crop_form.submit(function() {
+  $cropForm.submit(function() {
     return checkCoords();
   });
 
@@ -26,10 +26,10 @@ $(function(){
       $('#crop_panel .crop_preview img').each(function(){
         var rx = $(this).parent().width() / coords.w;
         var ry = $(this).parent().width() / coords.h;
-        $(this).attr('src', $target_image.attr('src'));
+        $(this).attr('src', $targetImage.attr('src'));
         $(this).css({
-          width: Math.round(rx * $target_image.width()) + 'px',
-          height: Math.round(ry * $target_image.height()) + 'px',
+          width: Math.round(rx * $targetImage.width()) + 'px',
+          height: Math.round(ry * $targetImage.height()) + 'px',
           marginLeft: '-' + Math.round(rx * coords.x) + 'px',
           marginTop: '-' + Math.round(ry * coords.y) + 'px',
           visibility: 'visible'
@@ -50,13 +50,14 @@ $(function(){
 
   function updatePreviewForm(coords)
   {
-    var w = $target_image[0].naturalWidth;
-    var h = $target_image[0].naturalHeight;
-    if (typeof w == "undefined") {
-      // IE 6/7/8 doesn't define naturalWidth etc, so load up a hidden copy to get the orig widths
+    var w = $targetImage[0].naturalWidth;
+    var h = $targetImage[0].naturalHeight;
+    if (typeof w == 'undefined') {
+      // IE 6/7/8 doesn't define naturalWidth etc, 
+      // so load up a hidden copy to get the original widths
 	  var newImg = new Image();
 	  newImg.onload = function() {fillForm(this.width, this.height, coords);};
-	  newImg.src = $target_image[0].src;
+	  newImg.src = $targetImage[0].src;
     } else {
       fillForm(w, h, coords);
     }
@@ -64,11 +65,11 @@ $(function(){
   
   function fillForm(w,h,c)
   {
-    //EoL specific: export the crop as percentages, since large images may be shrunk
+    //EoL specific: express crop as % not px, as large images may be shrunk
     // Offsets are from the 580 x 360 image. However, if they are wider than 
-    // 540px, the EoL CSS scales the image proportionally to fit into a max width of 540.
-    // The offsets and width need to be scaled to match the image dimensions
-    var scale_factor = 1;
+    // 540px, the EoL CSS scales the image proportionally to fit into a max 
+    // width of 540. %ages thus need scaling to match the image dimensions
+    var scaleFactor = 1;
     if((w / h) < ( 540 / 360 ))
     {
       //smaller width, so scaling only happens if height exceeds max
@@ -77,15 +78,15 @@ $(function(){
       //smaller height, so scaling only happens if width exceeds max
       if(w > 540) scale_factor = w / 540;
     }
-    $crop_form.children('[name="x"]').val(100.0 * c.x * scale_factor/w);
-    $crop_form.children('[name="y"]').val(100.0 * c.y * scale_factor/h);
-    $crop_form.children('[name="w"]').val(100.0 * c.w * scale_factor/w);
-    //$crop_form.children('[name="h"]').val(100.0 * c.h * scale_factor/h); //only needed for non-square crops
+    $cropForm.children('[name="x"]').val(100.0 * c.x * scaleFactor/w);
+    $cropForm.children('[name="y"]').val(100.0 * c.y * scaleFactor/h);
+    $cropForm.children('[name="w"]').val(100.0 * c.w * scaleFactor/w);
+    //$cropForm.children('[name="h"]').val(100.0 * c.h * scaleFactor/h); //only needed for non-square crops
   }
   
   function checkCoords()
   {
-    if (parseInt($crop_form.children('[name="w"]').val())>0) return true;
+    if (parseInt($cropForm.children('[name="w"]').val())>0) return true;
     alert('Please select a crop region in the larger image, then press "crop image".');
     return false;
   }

--- a/app/assets/javascripts/jcrop_data_objects.js
+++ b/app/assets/javascripts/jcrop_data_objects.js
@@ -73,10 +73,10 @@ $(function(){
     if((w / h) < ( 540 / 360 ))
     {
       //smaller width, so scaling only happens if height exceeds max
-      if(h > 360) scale_factor = h / 360;
+      if(h > 360) scaleFactor = h / 360;
     } else  {
       //smaller height, so scaling only happens if width exceeds max
-      if(w > 540) scale_factor = w / 540;
+      if(w > 540) scaleFactor = w / 540;
     }
     $cropForm.children('[name="x"]').val(100.0 * c.x * scaleFactor/w);
     $cropForm.children('[name="y"]').val(100.0 * c.y * scaleFactor/h);

--- a/lib/content_server.rb
+++ b/lib/content_server.rb
@@ -80,7 +80,7 @@ class ContentServer
     env_name = Rails.env.to_s
     env_name = 'staging' if Rails.env.staging_dev?
     env_name = 'bocce_demo' if Rails.env.bocce_demo_dev?
-    parameters = "function=crop_image&data_object_id=#{data_object_id}&x=#{x}&y=#{y}&w=#{w}&ENV_NAME=#{env_name}"
+    parameters = "function=crop_image_pct&data_object_id=#{data_object_id}&x=#{x}&y=#{y}&w=#{w}&ENV_NAME=#{env_name}"
     call_file_upload_api_with_parameters(parameters, "update data object crop service")
   end
 

--- a/spec/lib/content_server_spec.rb
+++ b/spec/lib/content_server_spec.rb
@@ -226,7 +226,7 @@ describe ContentServer do
         allow(ContentServer).to receive(:call_file_upload_api_with_parameters)
         subject # Calls it.
         expect(ContentServer).to have_received(:call_file_upload_api_with_parameters).
-          with("function=crop_image&data_object_id=123654&x=23&y=45&w=670&ENV_NAME=whatever",
+          with("function=crop_image_pct&data_object_id=123654&x=23&y=45&w=670&ENV_NAME=whatever",
                "update data object crop service")
       end
 
@@ -235,7 +235,7 @@ describe ContentServer do
         allow(ContentServer).to receive(:call_file_upload_api_with_parameters)
         subject # Calls it.
         expect(ContentServer).to have_received(:call_file_upload_api_with_parameters).
-          with("function=crop_image&data_object_id=123654&x=23&y=45&w=670&ENV_NAME=staging",
+          with("function=crop_image_pct&data_object_id=123654&x=23&y=45&w=670&ENV_NAME=staging",
                "update data object crop service")
       end
 
@@ -244,7 +244,7 @@ describe ContentServer do
         allow(ContentServer).to receive(:call_file_upload_api_with_parameters)
         subject # Calls it.
         expect(ContentServer).to have_received(:call_file_upload_api_with_parameters).
-          with("function=crop_image&data_object_id=123654&x=23&y=45&w=670&ENV_NAME=bocce_demo",
+          with("function=crop_image_pct&data_object_id=123654&x=23&y=45&w=670&ENV_NAME=bocce_demo",
                "update data object crop service")
       end
 

--- a/spec/lib/content_server_spec.rb
+++ b/spec/lib/content_server_spec.rb
@@ -220,13 +220,13 @@ describe ContentServer do
 
     context 'reasonable args' do
 
-      subject { ContentServer.update_data_object_crop(123654, 23, 45, 670) }
+      subject { ContentServer.update_data_object_crop(123654, 23, 45, 67) }
 
       it 'builds expected params' do
         allow(ContentServer).to receive(:call_file_upload_api_with_parameters)
         subject # Calls it.
         expect(ContentServer).to have_received(:call_file_upload_api_with_parameters).
-          with("function=crop_image_pct&data_object_id=123654&x=23&y=45&w=670&ENV_NAME=whatever",
+          with("function=crop_image_pct&data_object_id=123654&x=23&y=45&w=67&ENV_NAME=whatever",
                "update data object crop service")
       end
 
@@ -235,7 +235,7 @@ describe ContentServer do
         allow(ContentServer).to receive(:call_file_upload_api_with_parameters)
         subject # Calls it.
         expect(ContentServer).to have_received(:call_file_upload_api_with_parameters).
-          with("function=crop_image_pct&data_object_id=123654&x=23&y=45&w=670&ENV_NAME=staging",
+          with("function=crop_image_pct&data_object_id=123654&x=23&y=45&w=67&ENV_NAME=staging",
                "update data object crop service")
       end
 
@@ -244,7 +244,7 @@ describe ContentServer do
         allow(ContentServer).to receive(:call_file_upload_api_with_parameters)
         subject # Calls it.
         expect(ContentServer).to have_received(:call_file_upload_api_with_parameters).
-          with("function=crop_image_pct&data_object_id=123654&x=23&y=45&w=670&ENV_NAME=bocce_demo",
+          with("function=crop_image_pct&data_object_id=123654&x=23&y=45&w=67&ENV_NAME=bocce_demo",
                "update data object crop service")
       end
 


### PR DESCRIPTION
This moves the calculation on lines 686-717 of ContentManager.php to the javascript side. That means the php image cropping code in ContentManager.php becomes independent of the front-end web code (css etc). It should allow 62 lines (the crop_image function) to be cut from the php code. Annoyingly, the javascript replacement is slightly complicated by having to deal with the lack of the naturalWidth and naturalHeight properties in Internet Explorer 6, 7  and 8.

This code has not been tested on a full working system: in particular, I am not sure if the ruby code has been correctly changed so that the crop_image_pct() function is called instead of crop_image()